### PR TITLE
Global unique i ds

### DIFF
--- a/TenantFile/Api/Migrations/TenantFileContextModelSnapshot.cs
+++ b/TenantFile/Api/Migrations/TenantFileContextModelSnapshot.cs
@@ -15,9 +15,9 @@ namespace TenantFile.Api.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .UseIdentityByDefaultColumns()
                 .HasAnnotation("Relational:MaxIdentifierLength", 63)
-                .HasAnnotation("ProductVersion", "5.0.0");
+                .HasAnnotation("ProductVersion", "5.0.3")
+                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
             modelBuilder.Entity("PhoneTenant", b =>
                 {
@@ -39,7 +39,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<string>("City")
                         .IsRequired()
@@ -76,7 +76,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -115,7 +115,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<string>("OrganizerUid")
                         .HasColumnType("text");
@@ -136,7 +136,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<int>("AddressId")
                         .HasColumnType("integer");
@@ -161,7 +161,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<int>("AddressId")
                         .HasColumnType("integer");
@@ -183,7 +183,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<DateTime>("MoveIn")
                         .HasColumnType("timestamp without time zone");
@@ -211,7 +211,7 @@ namespace TenantFile.Api.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("integer")
-                        .UseIdentityByDefaultColumn();
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -256,7 +256,7 @@ namespace TenantFile.Api.Migrations
                             b1.Property<int>("Id")
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("integer")
-                                .UseIdentityByDefaultColumn();
+                                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
 
                             b1.Property<float?>("Confidence")
                                 .HasColumnType("real");

--- a/TenantFile/Api/Models/GraphQL/Addresses/AddressQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Addresses/AddressQueries.cs
@@ -22,7 +22,7 @@ namespace TenantFile.Api.Models.Addresses
         [UsePaging]
         [HotChocolate.Data.UseFiltering(typeof(AddressFilterInputType))]
         [HotChocolate.Data.UseSorting]
-        public IQueryable<Address> GetAddresses([ScopedService] TenantFileContext tenantContext) => tenantContext.Addresses.AsQueryable();
+        public IQueryable<Address> GetAddresses([ScopedService] TenantFileContext tenantContext) => tenantContext.Addresses.AsQueryable().OrderBy(a => a.PostalCode);
 
         public Task<Address> GetAddressAsync([ID(nameof(Address))] int id, AddressByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
 

--- a/TenantFile/Api/Models/GraphQL/Addresses/AddressQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Addresses/AddressQueries.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using TenantFile.Api.DataLoader;
 using TenantFile.Api.Extensions;
 using TenantFile.Api.Models.Entities;
+using HotChocolate.Types.Relay;
 
 namespace TenantFile.Api.Models.Addresses
 {
@@ -23,7 +24,7 @@ namespace TenantFile.Api.Models.Addresses
         [HotChocolate.Data.UseSorting]
         public IQueryable<Address> GetAddresses([ScopedService] TenantFileContext tenantContext) => tenantContext.Addresses.AsQueryable();
 
-        public Task<Address> GetAddressAsync(int id, AddressByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
+        public Task<Address> GetAddressAsync([ID(nameof(Address))] int id, AddressByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
 
     }
 }

--- a/TenantFile/Api/Models/GraphQL/Addresses/AddressType.cs
+++ b/TenantFile/Api/Models/GraphQL/Addresses/AddressType.cs
@@ -26,7 +26,6 @@ namespace TenantFile.Api.Models.Addresses
     public class AddressResolvers
     {
         public async Task<Address> GetAddress(Address address,
-            //[ScopedService] TenantFileContext context,
             AddressByIdDataLoader dataLoader,
             CancellationToken cancellationToken)
         {

--- a/TenantFile/Api/Models/GraphQL/Images/AddImageInput.cs
+++ b/TenantFile/Api/Models/GraphQL/Images/AddImageInput.cs
@@ -1,13 +1,17 @@
-﻿using TenantFile.Api.Models.Entities;
+﻿using HotChocolate.Types.Relay;
+using TenantFile.Api.Models.Entities;
 
 namespace TenantFile.Api.Models.Images
 {
     public record AddImageInput(
         string FileName,
-        Tenant Tenant,
-        Residence Residence,
+        string ThumbnailName,
+        [ID(nameof(Tenant))]
+        int Tenant,
+        [ID(nameof(Residence))]
+        int Residence,
         ImageLabel[] Labels
 
         );
-  
+
 }

--- a/TenantFile/Api/Models/GraphQL/Images/ImageMutations.cs
+++ b/TenantFile/Api/Models/GraphQL/Images/ImageMutations.cs
@@ -13,19 +13,37 @@ namespace TenantFile.Api.Models.Images
     [ExtendObjectType(Name = "Mutation")]
     public class ImageMutations
     {/// <summary>
-    /// Intended for use by Organizer uploading Images via dashboard, not for SMS/Twilio uploads
-    /// </summary>
-    /// <param name="input"></param>
-    /// <param name="context"></param>
-    /// <returns></returns>
+     /// Intended for use by Organizer uploading Images via dashboard, not for SMS/Twilio uploads
+     /// The relationshiup of the image and the residence is implied as of 2/11 would need to add a Property on the image or Residence Entity
+     /// </summary>
+     /// <param name="input"></param>
+     /// <param name="context"></param>
+     /// <returns></returns>
         [UseTenantFileContext]
 
         public async Task<AddImagePayload> AddImageAsync(
         AddImageInput input,
         [ScopedService] TenantFileContext context)
         {
-            var image = new Image{ Name = input.FileName };
+            var (fileName, thumb, tenantId, residenceId, labels) = input;
+
+            var image = new Image
+            {
+                Name = fileName,
+                Labels = labels,
+                ThumbnailName = thumb,
+
+            };
             context.Images.Add(image);
+            
+            var phones
+             = context.Phones.AsQueryable()
+                .Where(p => p.Tenants.Select(t => t.Id).Contains(tenantId)).ToList();
+                phones.ForEach(p => p.Images.Add(image));
+
+
+
+
             await context.SaveChangesAsync();
             return new AddImagePayload(image);
         }

--- a/TenantFile/Api/Models/GraphQL/Images/ImageQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Images/ImageQueries.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using HotChocolate;
 using HotChocolate.Data;
 using HotChocolate.Types;
+using HotChocolate.Types.Relay;
 using Microsoft.EntityFrameworkCore;
 using TenantFile.Api.DataLoader;
 using TenantFile.Api.Extensions;
@@ -23,6 +24,6 @@ namespace TenantFile.Api.Models.Images
         [HotChocolate.Data.UseSorting]
         public IQueryable<Image> GetImages([ScopedService] TenantFileContext tenantContext) => tenantContext.Images.AsNoTracking();
 
-        public Task<Image> GetImageAsync(int id, ImageByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
+        public Task<Image> GetImageAsync([ID(nameof(Image))] int id, ImageByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
     }
 }

--- a/TenantFile/Api/Models/GraphQL/Phones/PhoneQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Phones/PhoneQueries.cs
@@ -19,12 +19,20 @@ namespace TenantFile.Api.Models.Phones
   public class PhoneQueries
   {
 
+<<<<<<< Updated upstream
     [UseTenantFileContext]
     [UsePaging]
     [UseProjection]
     [HotChocolate.Data.UseFiltering(typeof(PhoneFilterInputType))]
     [HotChocolate.Data.UseSorting]
     public IQueryable<Phone> GetPhones([ScopedService] TenantFileContext tenantContext) => tenantContext.Phones.AsQueryable();
+=======
+        [UseTenantFileContext]
+        [UsePaging(typeof(NonNullType<PhoneType>))]
+        [HotChocolate.Data.UseFiltering(typeof(PhoneFilterInputType))]
+        [HotChocolate.Data.UseSorting]
+        public IQueryable<Phone> GetPhones([ScopedService] TenantFileContext tenantContext) => tenantContext.Phones.AsQueryable().OrderBy(p => p.PhoneNumber);
+>>>>>>> Stashed changes
 
     [UseTenantFileContext]
     public async Task<List<Phone>> GetTenantlessPhonesAsync(

--- a/TenantFile/Api/Models/GraphQL/Phones/PhoneType.cs
+++ b/TenantFile/Api/Models/GraphQL/Phones/PhoneType.cs
@@ -25,11 +25,26 @@ namespace TenantFile.Api.Models.Phones
             //   .ResolveNode((ctx, id) => ctx.DataLoader<DataLoaderById<Phone>>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor
+<<<<<<< Updated upstream
                  .Field(p => p.Images)
                 .ResolveWith<PhoneResolvers>(r =>  r.GetImagesAsync(default!, default!, default!, default!))
+=======
+                .Field(p => p.Images)
+>>>>>>> Stashed changes
                 .UseTenantContext<TenantFileContext>()
+                .ResolveWith<PhoneResolvers>(r =>  r.GetImagesAsync(default!, default!, default!, default))
                 .Name("images");
+<<<<<<< Updated upstream
            
+=======
+            descriptor
+                .Field(p => p.Tenants)
+                .UseTenantContext<TenantFileContext>()
+                // .UsePaging<NonNullType<TenantType>>()//You can only use this on one of the 
+                .ResolveWith<PhoneResolvers>(r =>  r.GetTenantsAsync(default!, default!, default!, default))
+                .Name("tenants");
+         
+>>>>>>> Stashed changes
 
         }
     }

--- a/TenantFile/Api/Models/GraphQL/Properties/PropertyQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Properties/PropertyQueries.cs
@@ -22,7 +22,7 @@ namespace TenantFile.Api.Models.Properties
         [UsePaging]
         [HotChocolate.Data.UseFiltering(typeof(PropertyFilterInputType))]
         [HotChocolate.Data.UseSorting]
-        public IQueryable<Property> GetProperties([ScopedService] TenantFileContext tenantContext) => tenantContext.Properties.AsQueryable();
+        public IQueryable<Property> GetProperties([ScopedService] TenantFileContext tenantContext) => tenantContext.Properties.AsQueryable().OrderBy(p => p.Name);
 
         public Task<Property> GetPropertyAsync([ID(nameof(Property))] int id, PropertyByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
 

--- a/TenantFile/Api/Models/GraphQL/Properties/PropertyQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Properties/PropertyQueries.cs
@@ -11,6 +11,7 @@ using TenantFile.Api.DataLoader;
 using TenantFile.Api.Extensions;
 using TenantFile.Api.Models.Entities;
 using TenantFile.Api.Services;
+using HotChocolate.Types.Relay;
 
 namespace TenantFile.Api.Models.Properties
 {
@@ -23,7 +24,7 @@ namespace TenantFile.Api.Models.Properties
         [HotChocolate.Data.UseSorting]
         public IQueryable<Property> GetProperties([ScopedService] TenantFileContext tenantContext) => tenantContext.Properties.AsQueryable();
 
-        public Task<Property> GetPropertyAsync(int id, PropertyByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
+        public Task<Property> GetPropertyAsync([ID(nameof(Property))] int id, PropertyByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
 
        
     }

--- a/TenantFile/Api/Models/GraphQL/Properties/PropertyType.cs
+++ b/TenantFile/Api/Models/GraphQL/Properties/PropertyType.cs
@@ -26,13 +26,13 @@ namespace TenantFile.Api.Models.Properties
 
             descriptor
                     .Field(p => p.Residences)
-                    .ResolveWith<PropertyResolvers>(r => r.GetResidencesAsync(default!, default!, default!, default!))
                     .UseTenantContext<TenantFileContext>()
+                    .ResolveWith<PropertyResolvers>(r => r.GetResidencesAsync(default!, default!, default!, default!))
                     .Name("residences");
             descriptor
                     .Field(p => p.Address)
-                    .ResolveWith<PropertyResolvers>(r => r.GetAddressAsync(default!, default!, default!))
                     .UseTenantContext<TenantFileContext>()
+                    .ResolveWith<PropertyResolvers>(r => r.GetAddressAsync(default!, default!, default!))
                     .Name("address");
 
 

--- a/TenantFile/Api/Models/GraphQL/Residences/ResidenceQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Residences/ResidenceQueries.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using HotChocolate;
 using HotChocolate.Data;
 using HotChocolate.Types;
+using HotChocolate.Types.Relay;
 using TenantFile.Api.DataLoader;
 using TenantFile.Api.Extensions;
 using TenantFile.Api.Models.Entities;
@@ -22,7 +23,7 @@ namespace TenantFile.Api.Models.Residences
         [HotChocolate.Data.UseSorting]
         public IQueryable<Residence> GetResidences([ScopedService] TenantFileContext tenantContext) => tenantContext.Residences.AsQueryable();
 
-        public Task<Residence> GetResidenceByIdAsync(int id, ResidenceByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
-        public async Task<IEnumerable<Residence>> GetResidencesByIdAsync(int[] ids, ResidenceByIdDataLoader dataLoader, CancellationToken cancellationToken) => await dataLoader.LoadAsync(ids, cancellationToken);
+        public Task<Residence> GetResidenceByIdAsync([ID(nameof(Residence))] int id, ResidenceByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
+        public async Task<IEnumerable<Residence>> GetResidencesByIdAsync([ID(nameof(Residence))] int[] ids, ResidenceByIdDataLoader dataLoader, CancellationToken cancellationToken) => await dataLoader.LoadAsync(ids, cancellationToken);
     }
 }

--- a/TenantFile/Api/Models/GraphQL/Residences/ResidenceQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Residences/ResidenceQueries.cs
@@ -21,7 +21,7 @@ namespace TenantFile.Api.Models.Residences
         [UsePaging]
         [HotChocolate.Data.UseFiltering(typeof(ResidenceFilterInputType))]
         [HotChocolate.Data.UseSorting]
-        public IQueryable<Residence> GetResidences([ScopedService] TenantFileContext tenantContext) => tenantContext.Residences.AsQueryable();
+        public IQueryable<Residence> GetResidences([ScopedService] TenantFileContext tenantContext) => tenantContext.Residences.AsQueryable().OrderBy(r => r.Address.PostalCode);
 
         public Task<Residence> GetResidenceByIdAsync([ID(nameof(Residence))] int id, ResidenceByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
         public async Task<IEnumerable<Residence>> GetResidencesByIdAsync([ID(nameof(Residence))] int[] ids, ResidenceByIdDataLoader dataLoader, CancellationToken cancellationToken) => await dataLoader.LoadAsync(ids, cancellationToken);

--- a/TenantFile/Api/Models/GraphQL/Residences/ResidenceType.cs
+++ b/TenantFile/Api/Models/GraphQL/Residences/ResidenceType.cs
@@ -25,12 +25,12 @@ namespace TenantFile.Api.Models.Residences
                 .ResolveNode((ctx, id) => ctx.DataLoader<ResidenceByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
 
             descriptor.Field(r => r.Address)
-                      .ResolveWith<ResidenceResolvers>(r => r.GetAddressAsync(default!, default!, default!))
                       .UseTenantContext<TenantFileContext>()
+                      .ResolveWith<ResidenceResolvers>(r => r.GetAddressAsync(default!, default!, default!))
                       .Name("address");
             descriptor.Field(r => r.Property)
-                      .ResolveWith<ResidenceResolvers>(r => r.GetPropertyAsync(default!, default!, default!))
                       .UseTenantContext<TenantFileContext>()
+                      .ResolveWith<ResidenceResolvers>(r => r.GetPropertyAsync(default!, default!, default!))
                       .Name("property");
         }
     }

--- a/TenantFile/Api/Models/GraphQL/Tenants/CreateTenantInput.cs
+++ b/TenantFile/Api/Models/GraphQL/Tenants/CreateTenantInput.cs
@@ -1,10 +1,37 @@
-﻿using TenantFile.Api.Models.Residences;
+﻿using HotChocolate.Types.Relay;
+using TenantFile.Api.Models.Entities;
+using TenantFile.Api.Models.Residences;
 
 namespace TenantFile.Api.Models.Tenants
 {
-  public record CreateTenantInput(
-      string Name,
-      string PhoneNumber,
-      CreateResidenceInput? CurrentResidence
-      );
+    public record CreateTenantInput(
+        string Name,
+        string PhoneNumber,
+        CreateResidenceInput? CurrentResidence,
+        [ID(nameof(Residence))] int? ResidenceId //this can be handled by the Residence Input if reconfigured
+        ){}
+    // {
+    //     public CreateTenantInput(string Name,
+    //     string PhoneNumber,
+    //     CreateResidenceInput? CurrentResidence) : this(Name, PhoneNumber, CurrentResidence, null)
+    //     {
+    //     }
+    //     public CreateTenantInput(string Name,
+    //     string PhoneNumber,
+    //     [ID(nameof(Residence))] int? ResidenceId) : this(Name, PhoneNumber, null, ResidenceId)
+    //     {
+    //     }
+    //     public void Deconstruct(out string name, out string phoneNumber, out CreateResidenceInput? currentResidence)
+    //     {
+    //         name = Name;
+    //         phoneNumber= PhoneNumber;
+    //         currentResidence = CurrentResidence;
+    //     }
+    //     public void Deconstruct(out string name, out string phoneNumber,[ID(nameof(Residence))] out int? residenceId)
+    //     {
+    //         name = Name;
+    //         phoneNumber= PhoneNumber;
+    //         residenceId = ResidenceId;
+    //     }
+    // }
 }

--- a/TenantFile/Api/Models/GraphQL/Tenants/CreateTenantInput.cs
+++ b/TenantFile/Api/Models/GraphQL/Tenants/CreateTenantInput.cs
@@ -10,28 +10,5 @@ namespace TenantFile.Api.Models.Tenants
         CreateResidenceInput? CurrentResidence,
         [ID(nameof(Residence))] int? ResidenceId //this can be handled by the Residence Input if reconfigured
         ){}
-    // {
-    //     public CreateTenantInput(string Name,
-    //     string PhoneNumber,
-    //     CreateResidenceInput? CurrentResidence) : this(Name, PhoneNumber, CurrentResidence, null)
-    //     {
-    //     }
-    //     public CreateTenantInput(string Name,
-    //     string PhoneNumber,
-    //     [ID(nameof(Residence))] int? ResidenceId) : this(Name, PhoneNumber, null, ResidenceId)
-    //     {
-    //     }
-    //     public void Deconstruct(out string name, out string phoneNumber, out CreateResidenceInput? currentResidence)
-    //     {
-    //         name = Name;
-    //         phoneNumber= PhoneNumber;
-    //         currentResidence = CurrentResidence;
-    //     }
-    //     public void Deconstruct(out string name, out string phoneNumber,[ID(nameof(Residence))] out int? residenceId)
-    //     {
-    //         name = Name;
-    //         phoneNumber= PhoneNumber;
-    //         residenceId = ResidenceId;
-    //     }
-    // }
+   
 }

--- a/TenantFile/Api/Models/GraphQL/Tenants/TenantMutations.cs
+++ b/TenantFile/Api/Models/GraphQL/Tenants/TenantMutations.cs
@@ -11,39 +11,71 @@ using TenantFile.Api.Models.Entities;
 
 namespace TenantFile.Api.Models.Tenants
 {
-  [ExtendObjectType(Name = "Mutation")]
-  public class TenantMutations
-  {
-    [UseTenantFileContext]
-    public async Task<CreateTenantPayload> CreateTenantAsync(
-        CreateTenantInput inputTenant,
-        [ScopedService] TenantFileContext context,
-        CancellationToken cancellationToken)
+    [ExtendObjectType(Name = "Mutation")]
+    public class TenantMutations
     {
-      // See if the phone number exists already
-      Phone? phone = context.Phones.FirstOrDefault(x => x.PhoneNumber == inputTenant.PhoneNumber);
-
-      // If it doesn't exist, create a new phone number
-      if (phone == null)
-      {
-        phone = new Phone
+        [UseTenantFileContext]
+        public async Task<CreateTenantPayload> CreateTenantAsync(
+            CreateTenantInput inputTenant,
+            [ScopedService] TenantFileContext context,
+            CancellationToken cancellationToken)
         {
-          PhoneNumber = inputTenant.PhoneNumber
-        };
-      }
-      var tenant = new Tenant
-      {
-        Name = inputTenant.Name,
-        Phones = new List<Phone> {
+            var (nameInput, phoneInput, residenceInput, residenceIdInput) = inputTenant;
+            // See if the phone number exists already
+            Phone? phone = context.Phones.FirstOrDefault(x => x.PhoneNumber == phoneInput);
+
+            //destructuring in c#! 
+
+            // If it doesn't exist, create a new phone number
+            if (phone == null)
+            {
+                phone = new Phone
+                {
+                    PhoneNumber = phoneInput
+                };
+            }
+            var tenant = new Tenant
+            {
+                Name = nameInput,
+                Phones = new List<Phone> {
                     phone
                 },
-      };
+                // CurrentResidence = new Residence(){
 
-      var tenantEntry = context.Tenants.Add(tenant);
-      await context.SaveChangesAsync(cancellationToken);
-      return new CreateTenantPayload(tenant);
+                //  Address = new Address(){
+                //      City = city
+                //  }
+                // } 
+
+            };
+
+            if (residenceInput != null)
+            {
+                var (line1, line2, line3, line4, city, state, postalCode) = residenceInput!.AddressInput;
+                tenant.CurrentResidence = new Residence()
+                {
+                    Address = new Address()
+                    {
+                        Line1 = line1,
+                        Line2 = line2,
+                        Line3 = line3,
+                        Line4 = line4,
+                        City = city,
+                        State = state,
+                        PostalCode = postalCode
+
+                    }
+                };
+            }
+            else
+            {
+                tenant.ResidenceId = residenceIdInput!;
+            }
+            var tenantEntry = context.Tenants.Add(tenant);
+            await context.SaveChangesAsync(cancellationToken);
+            return new CreateTenantPayload(tenant);
+        }
+
     }
-
-  }
 }
 

--- a/TenantFile/Api/Models/GraphQL/Tenants/TenantQueries.cs
+++ b/TenantFile/Api/Models/GraphQL/Tenants/TenantQueries.cs
@@ -16,12 +16,21 @@ namespace TenantFile.Api.Tenants
     public class TenantQueries
     {
         [UseTenantFileContext]
+<<<<<<< Updated upstream
         [UsePaging]
         [UseProjection]
+=======
+        [UsePaging(typeof(NonNullType<TenantType>))]
+>>>>>>> Stashed changes
         [HotChocolate.Data.UseFiltering(typeof(TenantFilterInputType))]
         [HotChocolate.Data.UseSorting]
-        public IQueryable<Tenant> GetTenants([ScopedService] TenantFileContext tenantContext) => tenantContext.Tenants.AsQueryable();
+        public IQueryable<Tenant> GetTenants([ScopedService] TenantFileContext tenantContext) => tenantContext.Tenants.AsQueryable().OrderBy(t => t.Name);
 
+<<<<<<< Updated upstream
         public Task<Tenant> GetTenantAsync([ID(nameof(Tenant))] int id, TenantByIdDataLoader dataLoader, CancellationToken cancellationToken) => dataLoader.LoadAsync(id, cancellationToken);
+=======
+        public async Task<Tenant> GetTenantAsync([ID(nameof(Tenant))] int id, TenantByIdDataLoader dataLoader, CancellationToken cancellationToken) => await dataLoader.LoadAsync(id, cancellationToken);
+        public async Task<IEnumerable<Tenant>> GetTenantsByIdsAsync([ID(nameof(Tenant))] int[] ids, TenantByIdDataLoader dataLoader, CancellationToken cancellationToken) => await dataLoader.LoadAsync(ids, cancellationToken);
+>>>>>>> Stashed changes
     }
 }

--- a/TenantFile/Api/Models/GraphQL/Tenants/TenantType.cs
+++ b/TenantFile/Api/Models/GraphQL/Tenants/TenantType.cs
@@ -23,8 +23,23 @@ namespace TenantFile.Api.Models.Tenants
                 .ResolveNode((ctx, id) => ctx.DataLoader<TenantByIdDataLoader>().LoadAsync(id, ctx.RequestAborted));
             descriptor
                 .Field(t => t.CurrentResidence)
+<<<<<<< Updated upstream
                 .ResolveWith<TenantResolvers>(resolver => resolver.GetResidenceAsync(default!, default!, default!))
                 .Name("residence");
+=======
+                .UseTenantContext<TenantFileContext>()
+                .ResolveWith<TenantResolvers>(resolver => resolver.GetResidenceAsync(default!, default!, default))
+                .Name("residence");
+            descriptor
+                .Field(t => t.Phones)
+                .UseTenantContext<TenantFileContext>()
+                .UsePaging<NonNullType<PhoneType>>()
+                .ResolveWith<TenantResolvers>(resolver => resolver.GetPhonesAsync(default!, default!, default!, default))
+                .Name("phones");
+            descriptor
+                .Field(t => t.ResidenceId)
+                .ID(nameof(Residence));
+>>>>>>> Stashed changes
         }
     }
     public class TenantResolvers
@@ -38,7 +53,30 @@ namespace TenantFile.Api.Models.Tenants
             {
                 return dataLoader.LoadAsync((int)tenant.ResidenceId, cancellationToken);
             }
+<<<<<<< Updated upstream
             return null;
+=======
+            return await dataLoader.LoadAsync((int)tenant.ResidenceId, cancellationToken);
+        }
+        [UseTenantFileContext]
+        public async Task<IEnumerable<Phone>> GetPhonesAsync(
+         Tenant tenant,
+         [ScopedService] TenantFileContext dbContext,
+         PhoneByIdDataLoader dataLoader,
+         CancellationToken cancellationToken
+     )
+        {
+
+            int[] phoneIds = await dbContext.Tenants
+                             .AsQueryable()
+                             //.Include(t => t.Phones)
+                                      .Where(t => t.Id == tenant.Id)
+                                      .SelectMany(t => t.Phones.Select(p => p.Id))
+                                      .ToArrayAsync();
+
+         
+            return await dataLoader.LoadAsync(phoneIds, cancellationToken );
+>>>>>>> Stashed changes
         }
     }
 }

--- a/TenantFile/Api/TenantFile.Api.csproj
+++ b/TenantFile/Api/TenantFile.Api.csproj
@@ -29,47 +29,47 @@
     <Compile Remove="Migrations\TenantContextModelSnapshot.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="5.0.0-rc1" />
+    <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
     <PackageReference Include="FirebaseAdmin" Version="2.0.0" />
     <PackageReference Include="Google.Cloud.Firestore" Version="2.0.0-beta02" />
     <PackageReference Include="Google.Cloud.Language.V1" Version="2.1.0" />
     <PackageReference Include="Google.Cloud.Storage.V1" Version="3.3.0" />
     <PackageReference Include="Google.Cloud.Vision.V1" Version="2.1.0" />
-    <PackageReference Include="HotChocolate.Data" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Subscriptions.Redis" Version="11.0.0" />
+    <PackageReference Include="HotChocolate.Data" Version="11.0.9" />
+    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="11.0.9" />
+    <PackageReference Include="HotChocolate.Subscriptions.Redis" Version="11.0.9" />
     <PackageReference Include="MediaTypeMap.Core" Version="2.3.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.0" />
-    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.0" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="11.0.9" />
     <PackageReference Include="HotChocolate.AspNetCore.Playground" Version="11.0.0-preview.138" />
     <PackageReference Include="HotChocolate.AspNetCore.Voyager" Version="11.0.0-preview.138" />
     <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Types" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Types.Filters" Version="11.0.0" />
+    <PackageReference Include="HotChocolate.Types" Version="11.0.9" />
+    <PackageReference Include="HotChocolate.Types.Filters" Version="11.0.9" />
     <PackageReference Include="HotChocolate.Types.Selections" Version="11.0.0-preview.138" />
-    <PackageReference Include="HotChocolate.Types.Sorting" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Subscriptions.InMemory" Version="11.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0">
+    <PackageReference Include="HotChocolate.Types.Sorting" Version="11.0.9" />
+    <PackageReference Include="HotChocolate.Subscriptions.InMemory" Version="11.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql" Version="5.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0" />
+    <PackageReference Include="Npgsql" Version="5.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="Twilio" Version="5.50.0" />
     <PackageReference Include="Twilio.AspNet.Core" Version="5.37.2" />
-    <PackageReference Include="HotChocolate" Version="11.0.0" />
-    <PackageReference Include="HotChocolate.Subscriptions" Version="11.0.0" />
+    <PackageReference Include="HotChocolate" Version="11.0.9" />
+    <PackageReference Include="HotChocolate.Subscriptions" Version="11.0.9" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Models\GraphQL\" />


### PR DESCRIPTION
- Updated HotChocolate and other dependent packages. [Most recent package](https://github.com/ChilliCream/hotchocolate/pull/2888) handles bug the caused #144. Closes #144 
- Implemented ID Types for all int Ids in GQL layer. Entities and database will still use ints. HotChocolate/Dataloaders handle the "coercion"
- Added logic to AddImage mutation to let the Organizer "assign"  and Image to a Tenant though Images are still tied to Phones in the model. This is for Organizers adding Images via the website and is seperate from the sms route.